### PR TITLE
fix: add script start in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "jest": "^28.1.0",
     "nodemon": "^2.0.16"
   },
-  "scripts": {},
+  "scripts": {
+    "start": " node ./src/app.js"
+  },
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
1: Causa do problema:
Não havia um script para executar a aplicação node
 
2: Porquê a alteração foi feita daquela maneira
Porque a aplicação node em express precisa de um script para subir o servidor


3: Como ela soluciona o problema encontrado.
Quando subimos o docker ele espera que o package.json tenha um  script  start  para que possa subir a aplicação.