### PR TITLE
fix: resove bug in cors origin

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,8 +10,13 @@ const port = Number(process.env.PORT || 8089)
 const app = express();
 
 const whitelist = [
-  // TODO whitelist
+  'localhost:8081'
 ]
+
+app.use(function (req, res, next) {
+  req.headers.origin = req.headers.origin || req.headers.host;
+  next();
+});
 
 app.use(cors({
   origin: function (origin, callback) {


### PR DESCRIPTION
1- A causa do problema
  A variável whitelist que é responsável por obter os domínios que podem utilizar os recursos da api estava vazia 
 e a função origem da biblioteca cors não consegue obter o dominio responsável pela requisição 

2 - O porquê a alteração foi feita daquela maneira
 Para adicionar o domínio responsavel da requisição para assim ser validada pela api levendo em consideração os domínios permitidos incluídos na variável whitelist

3 - como ela soluciona o problema encontrado.
 Foi incluso o dominio localhost:8081 na variável whitelist responsável por guardar os domínios  (host e porta a qual a api etá em execução )  e criado um middleware para recuperar o origin do cabeçalho da requisição quando não houver um origin pegar pelo host no cabeçalho
