### PR TITLE
fix: update id of table user to int

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE posts (
 );
 
 CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
+    id int PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL


### PR DESCRIPTION
1 - a causa do problema,
Ao tentar subir o container da erro de integridade

2 - o porquê a alteração foi feita daquela maneira
Para o id da tabela users ser auto incrementada o tipo precisa ser inteiro

3 - como ela soluciona o problema encontrado.
Faz com que o container seja criado corretamente (container saudável)