### PR TITLE
fix: update  port in mysql to listen in 3306

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - main:/var/lib/mysql
       - ./db/:/docker-entrypoint-initdb.d/
     ports:
-      - 3305:3305
+      - 3306:3306
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 1s
@@ -36,7 +36,7 @@ services:
     environment:
       WRITER_MYSQL_HOST: "mysql"
       WRITER_MYSQL_PASS: "root"
-      WRITER_MYSQL_PORT: "3305"
+      WRITER_MYSQL_PORT: "3306"
       WRITER_MYSQL_USER: "root"
       NODE_ENV: "development"
       PORT: "8081"


### PR DESCRIPTION
1 - a causa do problema
API não consegui consegui realizar uma connexão no mysql

2- o porquê a alteração foi feita daquela maneira
Pois por padrão o container do mysql roda na porta 3306

3 - como ela soluciona o problema encontrado.
Fazendo com que a API conecte ao banco de dados