### PR TITLE
fix: show id user after creation

### DIFF
--- a/src/modules/handlers/User/createUser.js
+++ b/src/modules/handlers/User/createUser.js
@@ -3,7 +3,7 @@ const httpStatusCodes = require('http-status-codes');
 const { httpErrorHandler } = require("../../common/handlers");
 const { createUserService } = require('../../services');
 
-const createUserHandler = (req, res, next) => {
+const createUserHandler = async (req, res, next) => {
     try{
         const {
             user_email,
@@ -11,7 +11,7 @@ const createUserHandler = (req, res, next) => {
             full_name
         } = req.body
 
-        const created_user = createUserService({
+        const created_user = await createUserService({
             user_email,
             user_password,
             full_name


### PR DESCRIPTION
1- a causa do problema,
Não retorna o id do usuário criado

2 - o porquê a alteração foi feita daquela maneira
Como o createUserRepositories é uma função assíncrona, o createUser do handles tem que chamar essa função também  de forma assíncrona.

3 - como ela soluciona o problema encontrado.
Faz com que os dados não sejam perdidos e possa ser retornados no momento esperado