### PR TITLE
fix: solve mothod of create Post

### DIFF
--- a/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
+++ b/src/modules/repositories/Post/createPostRepositories/createPostRepositories.js
@@ -13,7 +13,7 @@ const createPostRepositories = async ({
     try {
         const post_created = await transaction('posts').insert(post)
         
-        const has_response = !Array.isArray(post_created) && post_created.length > 0;
+        const has_response = Array.isArray(post_created) && post_created.length > 0;
 
         if (!has_response) {
             return {
@@ -21,6 +21,7 @@ const createPostRepositories = async ({
             }
         }
 
+        commitTransaction({transaction})
 
         return {
             post_created


### PR DESCRIPTION
1 - A causa do problema,
Não estava salvando os Posts  porque na validação tem uma variável ( has_response) que verifica se há registro no retorno do insert, por padrão o retorno é um array ,más na lógica dizia que o retorno não  podia ser um array, e também estava faltando a função commitTransaction para confirmar a inserção dos dados no banco 

2- O  porquê a alteração foi feita daquela maneira
Para que o fluxo continuasse seguindo normalmente e os dados podendo estar sendo inseridos no banco

3 - como ela soluciona o problema encontrado.
Fazendo com os dados para inserção (create Posts)  sejam inseridos de forma corretamente