### PR TITLE
fix: solve update data of   posts by id

### DIFF
--- a/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
@@ -11,8 +11,8 @@ const getPostByPostIdRepositories = async ({
     const { transaction } = await getTransaction();
 
     const response = await transaction('posts').where({ id: post_id })
-
-    const has_response = Array.isArray(response) && response.length === 0;
+   
+    const has_response = Array.isArray(response) && response.length > 0;
 
     if(!has_response){
         return {

--- a/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
@@ -16,8 +16,6 @@ const getPostByUserIdRepositories = async ({
         }
     }
 
-    const posts = response.forEach(post => post);
-
     return {
         response
     }

--- a/src/modules/repositories/Post/updatePostRepositories/updatePostRepositories.js
+++ b/src/modules/repositories/Post/updatePostRepositories/updatePostRepositories.js
@@ -19,6 +19,7 @@ const updatePostRepositories = async ({
             post_text
         })
 
+        commitTransaction({ transaction })
 
     } catch (err) {
         rollbackTransaction({ transaction })

--- a/src/modules/services/Post/updatePostService/updatePostService.js
+++ b/src/modules/services/Post/updatePostService/updatePostService.js
@@ -11,8 +11,9 @@ const updatePostService = async ({
     } = await getPostByPostIdRepositories({
         post_id: id
     });
+    
 
-    const has_post = Array.isArray(posts) && posts.length === 1;
+    const has_post = Array.isArray(posts) && posts.length > 0;
 
     if (!has_post) {
         throw new Error("Hasn't post to update")


### PR DESCRIPTION
1 - a causa do problema
No  repositorie getPostByPostIdRepositories ao fazer uma buscar existia uma lógica comparando o Post retornado igual zero, no service essa lógica também existe, caso essa condição não fosse igual a zero o fluxo do update não prosseguia
e no repositorie updatePostRepositories pôr o update ser em uma transação, estava faltando o método     commitTransaction 

2 - o porquê a alteração foi feita daquela maneira
Para que o fluxo de (update posts) não travasse ao realizar buscas antes de fazer a inserção , e assim  podendo fazer a atualização dos respectivos posts

3 - como ela soluciona o problema encontrado.
O método que atualiza posts não está parando no meio do fluxo de atualização (update) e podendo salvar os dados alterados no banco de dados.