### PR TITLE
fix: solove mothod delete post

### DIFF
--- a/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -4,13 +4,12 @@ const {
     rollbackTransaction
 } = require('../../../common/handlers')
 
-const deletePostRepositories = async (
+const deletePostRepositories = async ({
     post_id
-) => {
+}) => {
     const { transaction } = await getTransaction();
-
     try {
-        await transaction('posts').del()
+        await transaction('posts').where({id: post_id }).del()
 
         await commitTransaction({transaction})
         

--- a/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/src/modules/services/Post/deletePostService/deletePostService.js
@@ -10,7 +10,7 @@ const deletePostService = async ({
         post_id
     });
 
-    const has_post = Array.isArray(posts) && posts.length === 1;
+    const has_post = Array.isArray(posts) && posts.length > 0;
 
     if(!has_post){
         throw new Error("Hasn't post to delete")


### PR DESCRIPTION
1 - A causa do problema
Ao deletar um post estavam sendo deletados todos os posts pois não estava sendo passado  um identificador no momento do delete , alem  de ter erro de logica na busca de um único post

2 - O porquê a alteração foi feita daquela maneira
Ao passar o where no delite no repositorie (deletePostRepositories) com seu respectivo ID, o método é capaz de deletar posts específicos  

3 - como ela soluciona o problema encontrado.
Agora a aplicação não deleta todos os posts simultaneamente ao chamar o método delete post , e sim posts definidos por seu ID (identificador único) como esperado no método 