### PR TITLE
feat: return all posts when no id is provided in the search

### DIFF
--- a/src/modules/repositories/Post/getAllPostsRepositories/getAllPostsRepositories.js
+++ b/src/modules/repositories/Post/getAllPostsRepositories/getAllPostsRepositories.js
@@ -1,0 +1,25 @@
+const { 
+  client
+} = require('../../../common/handlers')
+
+const getAllPostsRepositories = async ()  => {
+
+  const response = await client('posts');
+
+  const has_posts = Array.isArray(response) && response.length > 0;
+
+  if(!has_posts){
+    return {
+      posts: []
+    }
+  }
+
+  return {
+    posts: response
+  }
+
+}
+
+module.exports = {
+  getAllPostsRepositories
+}

--- a/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
@@ -1,5 +1,4 @@
 const { 
-    client,
     getTransaction,
 } = require('../../../common/handlers');
 

--- a/src/modules/repositories/index.js
+++ b/src/modules/repositories/index.js
@@ -8,5 +8,6 @@ module.exports = Object.freeze({
     ...require('./Post/deletePostRepositories/deletePostRepositories'),
     ...require('./Post/getPostByPostIdRepositories/getPostByPostIdRepositories'),
     ...require('./Post/getPostByUserIdRepositories/getPostByUserIdRepositories'),
-    ...require('./Post/updatePostRepositories/updatePostRepositories')
+    ...require('./Post/updatePostRepositories/updatePostRepositories'),
+    ...require('./Post/getAllPostsRepositories/getAllPostsRepositories')
 })

--- a/src/modules/services/Post/listPostService/listPostService.js
+++ b/src/modules/services/Post/listPostService/listPostService.js
@@ -1,19 +1,30 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
-const { getPostByUserIdRepositories } = require("../../../repositories");
+const { getPostByUserIdRepositories, getAllPostsRepositories } = require("../../../repositories");
 
 const getPostByUserIdService = async ({
     user_id
 }) => {
 
+    const has_user_id = !!user_id && Number.isFinite(+user_id);
+
+    if (!has_user_id) {
+        const { posts } = await getAllPostsRepositories();
+
+        return {
+            posts
+        }
+    }
+
+
     const {
         user
     } = await getUserByIdService({
         user_id
-    })
+    });
 
     const has_author = Array.isArray(user) && user.length > 0;
 
-    if(has_author === false) {
+    if (has_author === false) {
         throw new Error("Missing author in database")
     }
 
@@ -24,6 +35,7 @@ const getPostByUserIdService = async ({
     return {
         posts
     };
+
 }
 
 module.exports = {


### PR DESCRIPTION
1 - a causa do problema
O método list do post tem um parâmetro que é opcional (ID),e este método citado não tem um tratamento para quando o parâmetro  não for  passado.

2 - o porquê a alteração foi feita daquela maneira
Para que o sistema possa tratar em caso o parâmetro não seja passado.

3 - como ela soluciona o problema encontrado.
Caso o usuário quiser fizer uma busca por posts e não passar o ID , ele receberá a lista de todos os posts, pois se  o parâmetro ID não é obrigatório significa que a busca não é somente por ID
