### PR TITLE
fix: return http-status-code 201 when successfully created

### DIFF
--- a/src/modules/handlers/Posts/createPost.js
+++ b/src/modules/handlers/Posts/createPost.js
@@ -16,7 +16,7 @@ const createPostHandler = async(req, res, next) => {
             author_id
         })
 
-        return res.status(httpStatusCodes.OK).send(created_post);
+        return res.status(httpStatusCodes.CREATED).send(created_post);
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }

--- a/src/modules/handlers/User/createUser.js
+++ b/src/modules/handlers/User/createUser.js
@@ -17,7 +17,7 @@ const createUserHandler = async (req, res, next) => {
             full_name
         })
 
-        return res.status(httpStatusCodes.OK).send(created_user);
+        return res.status(httpStatusCodes.CREATED).send(created_user);
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }


### PR DESCRIPTION
1 - A causa do problema
Retorna o http-status-code 200 ao criar users e posts

2 - o porquê a alteração foi feita daquela maneira
Seguindo as boas práticas, Quando uma requisição é completamente processada e um ou mais recursos foram criadas em decorrência disso devemos utilizar o http-status-code

3 - como ela soluciona o problema encontrado.
 O código de status HTTP indica para o cliente qual a condição atual correta sobre o processamento de sua requisição.