### PR TITLE
solve return of erros

### DIFF
--- a/src/modules/common/handlers/http-error-handler/http-error-handler.js
+++ b/src/modules/common/handlers/http-error-handler/http-error-handler.js
@@ -8,7 +8,9 @@ const httpErrorHandler = ({ req, res, error }) => {
   const error_id = uuid.v4();
 
   const response = {
-    type: `internal server error (${error_id})`,
+    type:  response_status_code == httpStatusCodes.INTERNAL_SERVER_ERROR 
+    ? `internal server error (${error_id})` 
+    : httpStatusCodes.getStatusText(error.statusCode)+" "+error_id ,
   };
 
   if (!is_internal) {
@@ -17,7 +19,7 @@ const httpErrorHandler = ({ req, res, error }) => {
       details: error.details || error,
     });
   }
-  const error_context = {
+  const error_context = { 
     error: String(error),
     error_id,
     request: {
@@ -32,6 +34,9 @@ const httpErrorHandler = ({ req, res, error }) => {
     response,
     stack: error.stackTrace
   };
+
+
+  
   console.log(JSON.stringify(error_context));
 
   return res.status(response_status_code).json(response).end();

--- a/src/modules/handlers/User/updateUser.js
+++ b/src/modules/handlers/User/updateUser.js
@@ -18,6 +18,7 @@ const updateUserHandler = async (req, res, next) => {
             user_password,
             full_name
         })
+        
 
         return res.status(httpStatusCodes.OK).send(updated_user);
     }catch(error){

--- a/src/modules/services/Post/createPostService/createPostService.js
+++ b/src/modules/services/Post/createPostService/createPostService.js
@@ -1,5 +1,6 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { createPostRepositories } = require("../../../repositories");
+const { handleError } = require("../../../../shared/errors/handleError")
 
 const createPostService = async (post) => {
 
@@ -14,9 +15,9 @@ const createPostService = async (post) => {
     })
 
     const has_author = Array.isArray(user) && user.length > 0;
-    
-    if(has_author === false) {
-        throw new Error("Hasn't author in database")
+
+    if (has_author === false) {
+        handleError("Hasn't author in database", 400)
     }
 
     const {
@@ -27,10 +28,10 @@ const createPostService = async (post) => {
 
     const has_post_created = Array.isArray(post_created) && post_created.length > 0;
 
-    if(has_post_created === false){
+    if (has_post_created === false) {
         return {
             post_created_id: []
-        }  
+        }
     }
 
     return {

--- a/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/src/modules/services/Post/deletePostService/deletePostService.js
@@ -1,4 +1,6 @@
 const { getPostByPostIdRepositories, deletePostRepositories } = require("../../../repositories");
+const { handleError } =  require("../../../../shared/errors/handleError")
+
 
 const deletePostService = async ({
     post_id
@@ -13,7 +15,7 @@ const deletePostService = async ({
     const has_post = Array.isArray(posts) && posts.length > 0;
 
     if(!has_post){
-        throw new Error("Hasn't post to delete")
+        handleError("Hasn't post to delete", 404)
     }
 
     const [post_to_delete] = posts;

--- a/src/modules/services/Post/listPostService/listPostService.js
+++ b/src/modules/services/Post/listPostService/listPostService.js
@@ -1,5 +1,6 @@
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
 const { getPostByUserIdRepositories, getAllPostsRepositories } = require("../../../repositories");
+const { handleError } = require('../../../../shared/errors/handleError')
 
 const getPostByUserIdService = async ({
     user_id
@@ -25,7 +26,7 @@ const getPostByUserIdService = async ({
     const has_author = Array.isArray(user) && user.length > 0;
 
     if (has_author === false) {
-        throw new Error("Missing author in database")
+        handleError("Missing author in database", 404)
     }
 
     const posts = await getPostByUserIdRepositories({

--- a/src/modules/services/Post/updatePostService/updatePostService.js
+++ b/src/modules/services/Post/updatePostService/updatePostService.js
@@ -1,6 +1,8 @@
 const { getPostByPostIdRepositories,updatePostRepositories } = require("../../../repositories");
 const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
-  
+const { handleError } = require("../../../../shared/errors/handleError")
+
+
   const updatePostService = async ({
     id,
     author_id,
@@ -17,7 +19,7 @@ const { getUserByIdService } = require("../../User/getUserByIdService/getUserByI
     const has_post = Array.isArray(posts) && posts.length > 0;
   
     if (!has_post) {
-        throw new Error("Hasn't post to update")
+        handleError("Hasn't post to update", 400)
     }
   
     const {
@@ -29,7 +31,7 @@ const { getUserByIdService } = require("../../User/getUserByIdService/getUserByI
     const has_author = Array.isArray(user) && user.length > 0;
     
     if(has_author === false) {
-        throw new Error("Hasn't author in database to update")
+        handleError("Hasn't author in database to update", 400)
     }
 
 

--- a/src/modules/services/User/deleteUserService/deleteUserService.js
+++ b/src/modules/services/User/deleteUserService/deleteUserService.js
@@ -1,4 +1,5 @@
 const { getUserRepositories, deleteUserRepositories } = require("../../../repositories");
+const { handleError } = require("../../../../shared/errors/handleError")
 
 const deleteUserService = async ({
     user_id
@@ -13,7 +14,7 @@ const deleteUserService = async ({
     const has_user = Array.isArray(users) && users.length === 1;
 
     if(!has_user){
-        throw new Error("No user to delete")
+        handleError("No user to delete", 404)
     }
 
     const [user_to_delete] = users;

--- a/src/modules/services/User/updateUserService/updateUserService.js
+++ b/src/modules/services/User/updateUserService/updateUserService.js
@@ -1,6 +1,7 @@
 const bcrypt = require('bcryptjs');
 const salt = bcrypt.genSaltSync(10);
 const { getUserRepositories, updateUserRepositories } = require("../../../repositories");
+const { handleError } = require("../../../../shared/errors/handleError")
 
 const updateUserService = async ({
     id,
@@ -18,7 +19,7 @@ const updateUserService = async ({
     const has_user = Array.isArray(users) && users.length === 1;
 
     if (!has_user) {
-        throw new Error("Missing user to update")
+        handleError("Missing user to update", 404)
     }
 
     const [user_to_update] = users;

--- a/src/shared/errors/handleError.js
+++ b/src/shared/errors/handleError.js
@@ -1,0 +1,7 @@
+const handleError = (message, statusCode = 400) => {
+  const error = new Error(message)
+        error.statusCode = statusCode
+        throw error
+}
+
+module.exports = { handleError }


### PR DESCRIPTION
1 - A causa do problema
As exceptions que são responsáveis por gerar erros caso  uma condição seja ou não realizada não estavam retornando um http-status-code,  e também não havia uma rotina para especificar o tipo de erro que estava sendo retornado.

2 - O  porquê a alteração foi feita daquela maneira
Para que seja mais simples passar a mensagem e o tipo de erro (http-status-code), como lógica foi desacoplada ela pode esta sendo utilizada em qualquer parte do sistema,

3 - como ela soluciona o problema encontrado.
Ao retornar um erro podemos especificar o tipo de erro (http-status-code), evitando que todo erro seja Internal-error pois esse tipo de error é apenas para condições inesperadas.
