### PR TITLE
fix: don´t return users or posts delted

### DIFF
--- a/src/modules/handlers/Posts/deletePost.js
+++ b/src/modules/handlers/Posts/deletePost.js
@@ -5,20 +5,18 @@ const { httpErrorHandler } = require("../../common/handlers");
 const { deletePostService } = require('../../services');
 
 const deletePostHandler = async (req, res, next) => {
-    try{
+    try {
 
         const {
             post_id
         } = req.query;
 
-        const {
-            deletedPost
-        } = await deletePostService({
+        await deletePostService({
             post_id
         })
 
-        return res.status(httpStatusCodes.OK).send({deletedPost})
-    }catch(error){
+        return res.status(httpStatusCodes.NO_CONTENT).send()
+    } catch (error) {
         return httpErrorHandler({ req, res, error })
     }
 }

--- a/src/modules/handlers/User/deleteUser.js
+++ b/src/modules/handlers/User/deleteUser.js
@@ -11,13 +11,11 @@ const deleteUserHandler = async (req, res, next) => {
             user_id
         } = req.query;
 
-        const {
-            deletedUser
-        } = await deleteUserService({
+        await deleteUserService({
             user_id
         })
 
-        return res.status(httpStatusCodes.OK).send({deletedUser})
+        return res.status(httpStatusCodes.NO_CONTENT).send()
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }

--- a/src/modules/services/Post/deletePostService/deletePostService.js
+++ b/src/modules/services/Post/deletePostService/deletePostService.js
@@ -24,9 +24,7 @@ const deletePostService = async ({
         post_id: post_to_delete.id
     })
 
-    return {
-        deletedPost: post_to_delete
-    };
+    
 }
 
 module.exports = {

--- a/src/modules/services/User/deleteUserService/deleteUserService.js
+++ b/src/modules/services/User/deleteUserService/deleteUserService.js
@@ -23,9 +23,6 @@ const deleteUserService = async ({
         user_id: user_to_delete.id
     })
 
-    return {
-        deletedUser: user_to_delete
-    };
 }
 
 module.exports = {


### PR DESCRIPTION
1 - a causa do problema
Está retornando dados dos users e posts aos fazer o delete

2 - o porquê a alteração foi feita daquela maneira
Ao usar o http-status-code 204, estou utilizando o status mais adequado para delete, pois O servidor não possui conteúdo que possa ser adicionado a resposta

3 - como ela soluciona o problema encontrado.
É melhor para reduzir o tráfego e simplesmente informar ao cliente que a exclusão foi concluída e não retornar nenhum corpo de resposta (já que o recurso foi excluído).