### PR TITLE
fix: throw error when user is not found by id

### DIFF
--- a/src/modules/repositories/User/getUserRepositories/getUserRepositories.js
+++ b/src/modules/repositories/User/getUserRepositories/getUserRepositories.js
@@ -9,15 +9,6 @@ const getUserRepositories = async ({
     
     const response = await client('users').where({ id: user_id })
 
-   
-    const has_response = Array.isArray(response) && response.length > 0;
-
-    if(!has_response){
-        return {
-            users: []
-        }
-    }
-
     return {
         users: response
     }

--- a/src/modules/services/User/getUserByIdService/getUserByIdService.js
+++ b/src/modules/services/User/getUserByIdService/getUserByIdService.js
@@ -1,4 +1,6 @@
+const { request } = require("express");
 const { getUserRepositories } = require("../../../repositories");
+const { handleError } = require("../../../../shared/errors/handleError");
 
 const getUserByIdService = async ({
     user_id
@@ -17,7 +19,12 @@ const getUserByIdService = async ({
         user_id
     });
 
+
     const has_single_user = Array.isArray(users) && users.length > 0;
+
+    if(!has_single_user){
+        handleError("Missing user in database", 404);
+    }
 
     return {
         user: users,


### PR DESCRIPTION
1 - a causa do problema
Quando não encontra um usuário pelo id trás um array vazio

2 - o porquê a alteração foi feita daquela maneira
O padrão do Repository é separar a lógica de acesso a dados, então movi a lógica para o service que por padrão é responsável pelas regras de negócios .

3 - como ela soluciona o problema encontrado.
Ao  fazer uma buscar por id em vez de retorna uma array vazio quando não encontrar um usuário,  trazer um erro, além de ser uma boa prática fica mais fácil de dar um redirect quando for necessário .