### PR TITLE
fix: save password correctly

### DIFF
--- a/src/modules/services/User/updateUserService/updateUserService.js
+++ b/src/modules/services/User/updateUserService/updateUserService.js
@@ -16,15 +16,14 @@ const updateUserService = async ({
         user_id: id
     });
 
-    const has_user = Array.isArray(users) && users.length === 1;
+    const has_user = Array.isArray(users) && users.length > 0;
 
     if (!has_user) {
-        handleError("Missing user to update", 404)
+        handleError("Missing user in database", 404)
     }
 
-    const [user_to_update] = users;
 
-    const crypt_password = bcrypt.hashSync(user_to_update.user_password, salt);
+    const crypt_password = bcrypt.hashSync(user_password, salt);
 
     await updateUserRepositories({
         id,
@@ -37,7 +36,6 @@ const updateUserService = async ({
         updatedUser: {
             id,
             user_email,
-            user_password,
             full_name
         }
     };


### PR DESCRIPTION
1 - a causa do problema
Ao atualizar a senha do user não estava sendo passada a nova senha para ser atualizada, estava pegando a senha antiga e reutilizando-a, também esta tendo retorno da senha (user_password).

2 - O porquê a alteração foi feita daquela maneira
Para conseguir atualizar a senha para a senha requerida , tenho que considerar a nova senha para inserção no momento de atualização do cadastro.
Ao não retornar a nova senha atualizada evito expôr dados sensíveis .

3 - Como ela soluciona o problema encontrado.
Agora a senha do user pode ser alterada para uma senha nova, antes estava  sempre sendo  atualizada para a mesma senha.
e ao não retorna a nova senha como resposta paramos de expôr dados sensíveis, sendo assim mais responsáveis  utilizando boas práticas.