### PR TITLE
fix: don't let empty data write to table users

### DIFF
--- a/src/modules/services/User/createUserService/createUserService.js
+++ b/src/modules/services/User/createUserService/createUserService.js
@@ -1,10 +1,18 @@
 const bcrypt = require('bcryptjs');
 const salt = bcrypt.genSaltSync(10);
 const { createUserRepositories } = require("../../../repositories");
+const { handleError } =  require("../../../../shared/errors/handleError");
 
 const createUserService = async (user) => {
 
     const crypt_password = bcrypt.hashSync(user.user_password, salt);
+
+     if(
+        user.user_password.trim() === ''
+        || user.user_email.trim() === ''
+     ){
+        handleError("user_password and user_email are required", 400)
+     }
 
     const {
         user_created

--- a/src/modules/services/User/updateUserService/updateUserService.js
+++ b/src/modules/services/User/updateUserService/updateUserService.js
@@ -10,6 +10,13 @@ const updateUserService = async ({
     full_name
 }) => {
 
+    if(
+        user_password.trim() === ''
+        || user_email.trim() === ''
+     ){
+        handleError("user_password and user_email are required", 400)
+     }
+
     const {
         users = []
     } = await getUserRepositories({


### PR DESCRIPTION
1 - A causa do problema
A  API aceita que possa ter escrita de dados vazios  no campo user_email e no campo user_password  da tablela users apesar do tipos serem NOT NUll.

2 - O porquê a alteração foi feita daquela maneira
Ao realizar um insert ou update de um user, vai ser obrigatório ser passado o campo user_email e user_password preenchidos,  criando assim uma validação antes de fazer a escrita no banco de dados 

3 - como ela soluciona o problema encontrado.
Após a obrigatoriedade  ter um user_email e user_password, ao fazer um cadastro ou um update garante que tais campos que são obrigatório no banco de dados não sejam preenchidos com valor vazio pois nulo é diferente de vazio e o banco de dados acaba recendo um valor vazio. Garantindo que um usuário tenha sempre seus campos  preenchidos de forma correta. não tendo apenas um ID (identificador único )
