### PR TITLE
 implementing integrity to the database

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,11 +1,5 @@
 USE `main`;
 
-CREATE TABLE posts (
-    id INT PRIMARY KEY AUTO_INCREMENT,
-    author_id INT NOT NULL,
-    post_text VARCHAR(200)
-);
-
 CREATE TABLE users (
     id int PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
@@ -13,9 +7,16 @@ CREATE TABLE users (
     user_password VARCHAR(200) NOT NULL
 );
 
+CREATE TABLE posts (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    author_id INT NOT NULL,
+    post_text VARCHAR(200),
+    CONSTRAINT `FK_PostsUsers` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`)
+);
+
+
 ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';
 
 ALTER USER 'root' IDENTIFIED WITH mysql_native_password BY 'root';
 
 FLUSH PRIVILEGES;
-

--- a/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByUserIdRepositories/getPostByUserIdRepositories.js
@@ -17,7 +17,7 @@ const getPostByUserIdRepositories = async ({
     }
 
     return {
-        response
+        posts: response
     }
 
 }

--- a/src/modules/services/Post/updatePostService/updatePostService.js
+++ b/src/modules/services/Post/updatePostService/updatePostService.js
@@ -1,5 +1,4 @@
-const { getPostByPostIdRepositories,updatePostRepositories } = require("../../../repositories");
-const { getUserByIdService } = require("../../User/getUserByIdService/getUserByIdService");
+const { getPostByPostIdRepositories,updatePostRepositories , getUserRepositories} = require("../../../repositories");
 const { handleError } = require("../../../../shared/errors/handleError")
 
 
@@ -23,14 +22,15 @@ const { handleError } = require("../../../../shared/errors/handleError")
     }
   
     const {
-        user
-    } = await getUserByIdService({
-        user_id: author_id
-    })
+        users 
+    } = await getUserRepositories({
+        user_id:author_id
+    });
 
-    const has_author = Array.isArray(user) && user.length > 0;
+
+    const has_author = Array.isArray(users) && users.length > 0;
     
-    if(has_author === false) {
+    if(!has_author) {
         handleError("Hasn't author in database to update", 400)
     }
 

--- a/src/modules/services/User/deleteUserService/deleteUserService.js
+++ b/src/modules/services/User/deleteUserService/deleteUserService.js
@@ -1,4 +1,4 @@
-const { getUserRepositories, deleteUserRepositories } = require("../../../repositories");
+const { getUserRepositories, deleteUserRepositories, getPostByUserIdRepositories } = require("../../../repositories");
 const { handleError } = require("../../../../shared/errors/handleError")
 
 const deleteUserService = async ({
@@ -11,10 +11,23 @@ const deleteUserService = async ({
         user_id
     });
 
+    const {
+        posts = []
+    } = await 
+    getPostByUserIdRepositories({ 
+        user_id 
+    });
+
     const has_user = Array.isArray(users) && users.length === 1;
+
+    const has_user_in_posts = Array.isArray(posts) && posts.length >  0;
 
     if(!has_user){
         handleError("No user to delete", 404)
+    }
+
+    if(has_user_in_posts){
+        handleError("cannot delete user who is assigned in posts", 409)
     }
 
     const [user_to_delete] = users;

--- a/src/modules/services/User/getUserByIdService/getUserByIdService.js
+++ b/src/modules/services/User/getUserByIdService/getUserByIdService.js
@@ -1,4 +1,4 @@
-const { request } = require("express");
+
 const { getUserRepositories } = require("../../../repositories");
 const { handleError } = require("../../../../shared/errors/handleError");
 


### PR DESCRIPTION
1 - A  causa do problema
Como a tabela posts não está ligada a tabela users por uma  FOREIGN KEY, podemos apagar autores (users) e seu id permanecer no post, mesmo não existindo.

2 - O porquê a alteração foi feita daquela maneira
Ao criar o database vai automaticamente criar um relacionamento entre a tabela posts e a tabela users. Onde 1 user pode ter 0 ou N  posts, e um post pode ter apenas 1 user.  
E  adicionando lógica para não permitir exclusão de user que já está atrelado a posts

3 - como ela soluciona o problema encontrado.
Mantendo o banco integro, não deixando um post está atrelado a um user (autor) inexistente . pois não podemos excluir um  user quando tal estivar atrelado a um post.
